### PR TITLE
Regex unicode ('v') flag

### DIFF
--- a/src/RichInputElement.js
+++ b/src/RichInputElement.js
@@ -101,7 +101,7 @@ export default class RichInputElement extends HTMLElement {
   attributeChangedCallback(name, oldValue, newValue) {
     if (name === 'stylepattern') {
       try {
-        this.#formatRegex = new RegExp(`^(?:${newValue})$`, 'd');
+        this.#formatRegex = new RegExp(`^(?:${newValue})$`, 'dv');
       } catch (e) {
         this.#formatRegex = null;
       }
@@ -142,8 +142,9 @@ export default class RichInputElement extends HTMLElement {
     this.#internals.setFormValue(value);
     this.#setValidityFromInput();
 
-    // If the output doesn't match the regex then there is no need to higlight
-    // the content so set `textContent`
+    // If the output doesn't match the regex pattern there is no need to 
+    // highlight the content. Instead we just set `textContent` on the output
+    // element and exit.
     const match = this.#formatRegex?.exec(value);
     if (!match) {
       this.#output.textContent = value;
@@ -415,8 +416,8 @@ export default class RichInputElement extends HTMLElement {
 
   /**
    * The regular expression pattern used to control styling of the input value.
-   * The pattern must match the entire input value, rather than matching a 
-   * substring.
+   * It's compiled with the `v` flag, so it's Unicode-aware. The pattern must 
+   * match the entire input value—not just part of it.
    * @htmlattr stylepattern
    * @type {string}
    */


### PR DESCRIPTION
This PR updates the `stylepattern` regular expression so it compiles with the `v` flag, making it unicode aware. This mirrors the native behaviour of `pattern`.

This should address #2 