### PR TITLE
Issue3 use inert attr

### DIFF
--- a/src/RichInputElement.js
+++ b/src/RichInputElement.js
@@ -54,7 +54,6 @@ export default class RichInputElement extends HTMLElement {
       classList.toggle('noselection', selectionStart !== null && selectionStart === selectionEnd);
     };
 
-    // when receiving focus update the ::selection styles
     this.addEventListener('focus', () => {
       // when receiving focus update the ::selection styles
       this.#updateSelectionStyles();
@@ -127,9 +126,9 @@ export default class RichInputElement extends HTMLElement {
   }
 
   #updateSelectionStyles() {
-    // It's not possible for ::selection to inherit values form the cascade
-    // so we query the host element styles and pass them on through a custom
-    // property.
+    // It's not possible for ::selection to inherit values from the cascade
+    // so we query the host element for its styles and pass them on through a 
+    // custom property.
     const { backgroundColor } = getComputedStyle(this, '::selection');
     this.#input.style.setProperty('--selection', backgroundColor);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,7 @@
   caret-color: fieldtext;
   background-color: field;
   line-height: 1;
-
+  cursor: text;
 }
 
 /** Feature detect Safari */

--- a/src/styles.css
+++ b/src/styles.css
@@ -87,12 +87,6 @@ See: https://html.spec.whatwg.org/multipage/input.html#do-not-apply
 input.noselection+output {
   order:-1
 }
-/*
-input { z-index:1}
-*/
-output {
-  pointer-events: none;
-}
 
 input {
   text-shadow: none;

--- a/src/template.html
+++ b/src/template.html
@@ -2,6 +2,6 @@
 <div tabindex="-1">
   <span>
     <input>
-    <output aria-hidden="true"></output>
+    <output inert></output>
   </span>
 </div>


### PR DESCRIPTION
This PR adds the `inert` attribute to the `<output>` element to exclude it from a11y tree and in-page search.

Addresses #3 